### PR TITLE
NOISSUE buffer offset length 4 instead of 1

### DIFF
--- a/src/adv2_frames_index.cpp
+++ b/src/adv2_frames_index.cpp
@@ -86,7 +86,7 @@ void Adv2FramesIndex::WriteIndex(FILE *file)
 	unsigned int buffOffset = 9;
 	advfwrite(&buffOffset, 4, 1, file);
 
-	buffOffset = (unsigned int)m_MainIndexEntries->size() * 20 + 10;
+	buffOffset = (unsigned int)m_MainIndexEntries->size() * 20 + 13;
 	advfwrite(&buffOffset, 4, 1, file);
 
 	unsigned int framesCount = (unsigned int)m_MainIndexEntries->size();


### PR DESCRIPTION
Hi Hristo,
it seems the offset is 3 bytes off (first buffer offset at position 9, 4 bytes long = 13 instead of 10)
cheers, Andreas