### PR TITLE
NOISSUE The stream metadata table is optional; if the offset is zero, we must not try to parse it.

### DIFF
--- a/src/adv2_file.cpp
+++ b/src/adv2_file.cpp
@@ -348,8 +348,12 @@ int Adv2File::LoadFile(const char* fileName, AdvFileInfo* fileInfo)
 	unsigned char tagsCount;
 
 	// Read MAIN stream metadata table
-	advfsetpos64(m_Adv2File, &streamHeaderOffsets[0]);
-	advfread(&tagsCount, 1, 1, m_Adv2File);
+	// Optional, missing if the offset is 0
+	tagsCount = 0;
+	if (streamHeaderOffsets[0]) {
+		advfsetpos64(m_Adv2File, &streamHeaderOffsets[0]);
+		advfread(&tagsCount, 1, 1, m_Adv2File);
+	}
 	fileInfo->MainStreamTagsCount = tagsCount;
 	for (int i = 0; i < tagsCount; i++)
 	{
@@ -360,8 +364,11 @@ int Adv2File::LoadFile(const char* fileName, AdvFileInfo* fileInfo)
 	}
 
 	// Read CALIBRATION stream metadata table
-	advfsetpos64(m_Adv2File, &streamHeaderOffsets[1]);
-	advfread(&tagsCount, 1, 1, m_Adv2File);
+	tagsCount = 0;
+	if (streamHeaderOffsets[1]) {
+		advfsetpos64(m_Adv2File, &streamHeaderOffsets[1]);
+		advfread(&tagsCount, 1, 1, m_Adv2File);
+	}
 	fileInfo->CalibrationStreamTagsCount = tagsCount;
 	for (int i = 0; i < tagsCount; i++)
 	{

--- a/src/adv2_file.cpp
+++ b/src/adv2_file.cpp
@@ -925,6 +925,13 @@ ADVRESULT Adv2File::GetFrameImageSectionHeader(int streamId, int frameId, unsign
 			// Skip 1 byte of streamId, 16 bytes of start and end timestamps and 4 bytes of section size
 			advfseek(m_Adv2File, 1 + 16 + 4, SEEK_CUR);
 
+			// TODO
+			// According to the spec, the stream ID is repeated 
+			// in the ADV image section of the FSTF frame and should be read 
+			// or skipped here. However, this would break existing ADV files 
+			// and software, so it may be simpler to update the specification.
+			// fread(streamId, 1, 1, m_Adv2File);
+
 			fread(layoutId, 1, 1, m_Adv2File);
 
 			unsigned char byteMode;


### PR DESCRIPTION
The specification says about the offset:

Offset from the beginning of the file of an optional metadata header for the first data stream. If there is no metadata associated with this data stream the value MUST be Zero.

Consequently, if the offset is zero, the code shouldn't try to read the header.